### PR TITLE
Minor (25%) improvements for the creation of the Green's function

### DIFF
--- a/src/glaInt.jl
+++ b/src/glaInt.jl
@@ -34,14 +34,13 @@ edge-adjacent triangles, and vertex-adjacent triangles.
 The article cited above contains useful error comparison plots for the number 
 evaluation points considered. 
 =#
-const π = 3.1415926535897932384626433832795028841971693993751058209749445923
 #=
 Returns the scalar (Helmholtz) Green function. The separation dstMag is assumed 
 to be scaled by wavelength. 
 =#
 @inline function sclEgo(dstMag::AbstractFloat, frqPhz::T)::ComplexF64 where
 	T<:Union{ComplexF64,ComplexF32}
-	return exp(2im * π * dstMag * frqPhz) / (4 * π * dstMag * frqPhz^2)
+	return cis(2π * dstMag * frqPhz) / (4 * π * dstMag * frqPhz^2)
 end
 #=
 Returns the scalar (Helmholtz) Green function with the singularity removed. The 
@@ -52,7 +51,7 @@ all weakly singular integrals.
 @inline function sclEgoN(dstMag::AbstractFloat, frqPhz::T)::ComplexF64 where 
 	T<:Union{ComplexF64,ComplexF32}
     if dstMag > 1e-7
-        return (exp(2im * π * dstMag * frqPhz) - 1) / 
+        return (cis(2π * dstMag * frqPhz) - 1) / 
         (4 * π * dstMag * frqPhz^2)
     else
         return ((im / frqPhz) - π * dstMag) / 2

--- a/src/glaLinAlg.jl
+++ b/src/glaLinAlg.jl
@@ -118,14 +118,14 @@ function Base.show(io::IO, opr::GlaOpr)
 	end
 	print(io, "GlaOpr for ")
 	if isselfoperator(opr)
-		print(io, "a $(eltype(opr)) (" * join(opr.mem.srcVol.cel, "×") * ") 
-			volume ")
+		print(io, "a $(eltype(opr)) (" * join(opr.mem.srcVol.cel, "×") *
+			  ") volume ")
 		print(io, "of size (" * join(opr.mem.srcVol.scl, "×") * ")λ")
 	else
-		print(io, "$(eltype(opr)) (" * join(opr.mem.srcVol.cel, "×") * ") 
-			-> (" * join(opr.mem.trgVol.cel, "×") * ") volumes ")
-		print(io, "of sizes (" * join(opr.mem.srcVol.scl, "×") * ")λ 
-			-> (" * join(opr.mem.trgVol.scl, "×") * ")λ ")
+		print(io, "$(eltype(opr)) (" * join(opr.mem.srcVol.cel, "×") *
+			  ") -> (" * join(opr.mem.trgVol.cel, "×") * ") volumes ")
+		print(io, "of sizes (" * join(opr.mem.srcVol.scl, "×") *
+			  ")λ -> (" * join(opr.mem.trgVol.scl, "×") * ")λ ")
 		print(io, "with separation (" * join(opr.mem.trgVol.org .- 
 			opr.mem.srcVol.org, ", ") * ")λ")
 	end


### PR DESCRIPTION
I tried the following:

* Using `sincos` instead of `sin` and `cos` in `glaIntSup.jl`: 20% speedup
* Using `expm1` instead of `exp(...) - 1` in `sclEgoN` in `glaInt.jl`: 20% slowdown (UNUSED)
* Using `@fastmath` for the `/` in `sclEgoN` in `glaInt.jl`: 5% speedup (UNUSED)
* Using `cis` instead of `exp` in `sclEgoN` in `glaInt.jl`: 2% speedup
* Using the default π in `glaInt.jl`: 2% speedup

In the end, I find roughly 25% speedup for the creation of Green's operators with these changes.

I did not use the `@fastmath` improvement because fastmath can lead to inaccuracies, and for only a 5% speedup, I did not think it was worth the potential bugs.

Note that the [docs](https://docs.julialang.org/en/v1/base/math/#Base.expm1) say that `expm1` is more accurate than `exp(...) - 1`, but in incurred so much of a slowdown that I did not use it (we also have "enough" accuracy according to the tests, so I felt this was ok)

I also have a little fix in `glaLinAlg.jl` for the `Base.show` function, there was an unintended newline that slipped in in a previous commit.