### PR TITLE
Add new workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,18 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
+          flags: ${{ matrix.os }}-julia-${{ matrix.version }}
+          fail_ci_if_error: true
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - run: |
@@ -58,5 +61,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto        # pass if coverage does not drop vs base commit
+        threshold: 1%       # allow up to 1% drop without failing
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+
+ignore:
+  - "docs/**"
+  - "test/**"
+  - "benchmark/**"
+  - "examples/**"

--- a/test/aquaTest.jl
+++ b/test/aquaTest.jl
@@ -1,0 +1,10 @@
+using Aqua
+
+@testset "Aqua quality checks" begin
+    # `persistent_tasks` is disabled: its probe subprocess fails to precompile
+    # when CUDA is in the dependency closure (Aqua reports "done.log was not
+    # created, but precompilation exited"). GilaElectromagnetics has no
+    # `__init__` and spawns no tasks, so this is a false positive from the
+    # check itself rather than a real persistent task. All other checks run.
+    Aqua.test_all(GilaElectromagnetics; persistent_tasks=false)
+end


### PR DESCRIPTION
This PR introduces several additions to the CI/CD pipeline. The main changes include updating and configuring GitHub Actions workflows, adding a configuration for Dependabot to automate dependency updates, integrating Aqua quality checks, and setting up a detailed Codecov configuration for coverage reporting.

**CI/CD**

* Updated GitHub Actions workflow (`.github/workflows/ci.yml`) to use the latest versions of actions, including upgrading `codecov/codecov-action` from v1/v3 to v5, adding new flags, and ensuring the workflow fails if coverage upload fails. Also upgraded `actions/checkout` and `julia-actions/setup-julia` to newer versions.
* Added a Dependabot configuration (`.github/dependabot.yml`) to automate updates for GitHub Actions dependencies on a weekly schedule, with appropriate labeling.

**Code Quality and Coverage:**

* Added an Aqua quality check test (`test/aquaTest.jl`) to automatically run static analysis and quality checks, with a note explaining why the `persistent_tasks` check is disabled.
* Introduced a `codecov.yml` configuration file to fine-tune coverage reporting, including thresholds, patch targets, comment layout, and ignored paths (such as `docs/`, `test/`, `benchmark/`, and `examples/`).
* Removed redundant or outdated coverage upload steps in the documentation workflow to streamline the process.

We still need to add `test/aquaTest.jl` to `test/runtests.jl` once we'll have merged #6. We also still need to upload the codecov token (I think) to this repo:

1. Log into codecov.io
2. Navigate to Gila repo
3. Copy token from Settings -> General
4. Add it to the secrets in the Gila repo on github
    4.1 Go to go Settings in the Gila repo on github
    4.2 Go to Security -> Secrets and variables
    4.3 In actions, click "New repository secret"
    4.4 In the "Name" field, put `CODECOV_TOKEN`
    4.5 In the "Secret" field, put the token

We'll also need to update Project.toml to add Aqua, but to avoid merge conflicts with #6, I 've omitted this here. It'll be a simple `] add Aqua` and `] update` from there. The order should be: merge #6, then merge this PR. 